### PR TITLE
fix: Linker scripts and manifest updates for secure partition support

### DIFF
--- a/platform/common/src/pal_misc_asm.S
+++ b/platform/common/src/pal_misc_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2022-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -12,53 +12,54 @@
 
 .equ STACK_SIZE, 0x1000
 
-     .globl pal_uart_putc_hypcall
+.globl pal_uart_putc_hypcall
 pal_uart_putc_hypcall:
-
-    mov x2, x0 /* Char c*/
+    mov x2, x0 /* Char c */
     mov x1, #1
     mov x0, #0x8A /* FID */
     movk x0, #0xC400, lsl #16
 #if (PLATFORM_SP_EL == 0)
-    svc     #0
+    svc #0
 #else
     hvc #0
 #endif
     ret
 
-    /* int32_t pal_syscall_for_psci(uint64_t fid, uint64_t x1, uint64_t x2, uint64_t x3); */
-    .globl pal_syscall_for_psci
+/* int32_t pal_syscall_for_psci(uint64_t fid, uint64_t x1, uint64_t x2, uint64_t x3); */
+.globl pal_syscall_for_psci
 pal_syscall_for_psci:
     smc #0
     ret
 
-  .globl pal_secondary_cpu_boot_entry
+.globl pal_secondary_cpu_boot_entry
 pal_secondary_cpu_boot_entry:
-
     /* Temporary stack setup to call C function */
     mov x0, xzr
-    adr x1, stack_base + STACK_SIZE
-    mov x2, #STACK_SIZE
-    mul x2, x0, x2
-    add sp, x1, x2
+    adrp x1, stack_base
+    add  x1, x1, :lo12:stack_base
+    add  x1, x1, #STACK_SIZE
+    mov  x2, #STACK_SIZE
+    mul  x2, x0, x2
+    add  sp, x1, x2
 
     /* Get logical cpuid for sec cpu */
     mrs x0, mpidr_el1
     bl pal_get_cpuid
 
     /* Use separate stack for each of the sec cpus */
-    adr x1, stack_base + STACK_SIZE
-    mov x2, #STACK_SIZE
-    mul x2, x0, x2
-    add sp, x1, x2
+    adrp x1, stack_base
+    add  x1, x1, :lo12:stack_base
+    add  x1, x1, #STACK_SIZE
+    mov  x2, #STACK_SIZE
+    mul  x2, x0, x2
+    add  sp, x1, x2
 
     bl val_secondary_cpu_test_entry
 
     ret
 
-  .section .bss.stack_space, "aw"
-  /* Reserve stack area for sec cpus */
-  .balign 128
-      .global stack_base
+.section .bss.stack_space, "aw"
+    .balign 128
+    .global stack_base
 stack_base:
-  .fill  STACK_SIZE * 16
+    .fill STACK_SIZE * 16

--- a/platform/manifest/tgt_tfa_fvp/fvp_spmc_manifest.dts
+++ b/platform/manifest/tgt_tfa_fvp/fvp_spmc_manifest.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -34,28 +34,28 @@
 			debug_name = "ff-a-acs SP1";
 			load_address = <0x7000000>;
 			vcpu_count = <8>;
-			mem_size = <1048576>;
+			mem_size = <2097152>;
 		};
 		vm2 {
 			is_ffa_partition;
 			debug_name = "ff-a-acs SP2";
-			load_address = <0x7100000>;
+			load_address = <0x7200000>;
 			vcpu_count = <8>;
-			mem_size = <1048576>;
+			mem_size = <2097152>;
 		};
 		vm3 {
 			is_ffa_partition;
 			debug_name = "ff-a-acs SP3";
-			load_address = <0x7200000>;
+			load_address = <0x7400000>;
 			vcpu_count = <1>;
-			mem_size = <1048576>;
+			mem_size = <2097152>;
 		};
 		vm4 {
 			is_ffa_partition;
 			debug_name = "ff-a-acs SP4";
-			load_address = <0x7300000>;
+			load_address = <0x7600000>;
 			vcpu_count = <1>;
-			mem_size = <1048576>;
+			mem_size = <2097152>;
 		};
 	};
 

--- a/platform/manifest/tgt_tfa_fvp/fvp_spmc_manifest_el0.dts
+++ b/platform/manifest/tgt_tfa_fvp/fvp_spmc_manifest_el0.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -34,28 +34,28 @@
 			debug_name = "ff-a-acs SP1";
 			load_address = <0x7000000>;
 			vcpu_count = <1>;
-			mem_size = <1048576>;
+			mem_size = <2097152>;
 		};
 		vm2 {
 			is_ffa_partition;
 			debug_name = "ff-a-acs SP2";
-			load_address = <0x7100000>;
+			load_address = <0x7200000>;
 			vcpu_count = <1>;
-			mem_size = <1048576>;
+			mem_size = <2097152>;
 		};
 		vm3 {
 			is_ffa_partition;
 			debug_name = "ff-a-acs SP3";
-			load_address = <0x7200000>;
+			load_address = <0x7400000>;
 			vcpu_count = <1>;
-			mem_size = <1048576>;
+			mem_size = <2097152>;
 		};
 		vm4 {
 			is_ffa_partition;
 			debug_name = "ff-a-acs SP4";
-			load_address = <0x7300000>;
+			load_address = <0x7600000>;
 			vcpu_count = <1>;
-			mem_size = <1048576>;
+			mem_size = <2097152>;
 		};
 	};
 

--- a/platform/manifest/tgt_tfa_fvp/fvp_spmc_manifest_linux.dts
+++ b/platform/manifest/tgt_tfa_fvp/fvp_spmc_manifest_linux.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -34,28 +34,28 @@
 			debug_name = "ff-a-acs SP1";
 			load_address = <0x7000000>;
 			vcpu_count = <8>;
-			mem_size = <1048576>;
+			mem_size = <2097152>;
 		};
 		vm2 {
 			is_ffa_partition;
 			debug_name = "ff-a-acs SP2";
-			load_address = <0x7100000>;
+			load_address = <0x7200000>;
 			vcpu_count = <8>;
-			mem_size = <1048576>;
+			mem_size = <2097152>;
 		};
 		vm3 {
 			is_ffa_partition;
 			debug_name = "ff-a-acs SP3";
-			load_address = <0x7200000>;
+			load_address = <0x7400000>;
 			vcpu_count = <1>;
-			mem_size = <1048576>;
+			mem_size = <2097152>;
 		};
 		vm4 {
 			is_ffa_partition;
 			debug_name = "ff-a-acs SP4";
-			load_address = <0x7300000>;
+			load_address = <0x7600000>;
 			vcpu_count = <1>;
-			mem_size = <1048576>;
+			mem_size = <2097152>;
 		};
 	};
 

--- a/platform/manifest/tgt_tfa_fvp/v11/sp2.dts
+++ b/platform/manifest/tgt_tfa_fvp/v11/sp2.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -20,7 +20,7 @@
     execution-ctx-count = <8>;
     exception-level = <2>; /* S-EL1 */
     execution-state = <0>; /* AARCH64 */
-    load-address = <0x7100000>;
+    load-address = <0x7200000>;
     entrypoint-offset = <0x4000>;
     xlat-granule = <0>; /* 4KiB */
     boot-order = <1>;

--- a/platform/manifest/tgt_tfa_fvp/v11/sp2_el0.dts
+++ b/platform/manifest/tgt_tfa_fvp/v11/sp2_el0.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -17,7 +17,7 @@
     execution-ctx-count = <1>;
     exception-level = <1>; /* S-EL0 */
     execution-state = <0>; /* AARCH64 */
-    load-address = <0x7100000>;
+    load-address = <0x7200000>;
     entrypoint-offset = <0x4000>;
     xlat-granule = <0>; /* 4KiB */
     boot-order = <1>;

--- a/platform/manifest/tgt_tfa_fvp/v11/sp3.dts
+++ b/platform/manifest/tgt_tfa_fvp/v11/sp3.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -20,7 +20,7 @@
     execution-ctx-count = <1>;
     exception-level = <2>; /* S-EL1 */
     execution-state = <0>; /* AARCH64 */
-    load-address = <0x7200000>;
+    load-address = <0x7400000>;
     entrypoint-offset = <0x4000>;
     xlat-granule = <0>; /* 4KiB */
     boot-order = <2>;

--- a/platform/manifest/tgt_tfa_fvp/v11/sp3_el0.dts
+++ b/platform/manifest/tgt_tfa_fvp/v11/sp3_el0.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -18,7 +18,7 @@
     execution-ctx-count = <1>;
     exception-level = <1>; /* S-EL0 */
     execution-state = <0>; /* AARCH64 */
-    load-address = <0x7200000>;
+    load-address = <0x7400000>;
     entrypoint-offset = <0x4000>;
     xlat-granule = <0>; /* 4KiB */
     boot-order = <2>;

--- a/platform/manifest/tgt_tfa_fvp/v11/sp4.dts
+++ b/platform/manifest/tgt_tfa_fvp/v11/sp4.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -20,7 +20,7 @@
     execution-ctx-count = <1>;
     exception-level = <2>; /* S-EL1 */
     execution-state = <0>; /* AARCH64 */
-    load-address = <0x7300000>;
+    load-address = <0x7600000>;
     entrypoint-offset = <0x4000>;
     xlat-granule = <0>; /* 4KiB */
     boot-order = <3>;

--- a/platform/manifest/tgt_tfa_fvp/v11/sp4_el0.dts
+++ b/platform/manifest/tgt_tfa_fvp/v11/sp4_el0.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -18,7 +18,7 @@
     execution-ctx-count = <1>;
     exception-level = <1>; /* S-EL0 */
     execution-state = <0>; /* AARCH64 */
-    load-address = <0x7300000>;
+    load-address = <0x7600000>;
     entrypoint-offset = <0x4000>;
     xlat-granule = <0>; /* 4KiB */
     boot-order = <3>;

--- a/platform/manifest/tgt_tfa_fvp/v12/sp2.dts
+++ b/platform/manifest/tgt_tfa_fvp/v12/sp2.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -20,7 +20,7 @@
     execution-ctx-count = <8>;
     exception-level = <2>; /* S-EL1 */
     execution-state = <0>; /* AARCH64 */
-    load-address = <0x7100000>;
+    load-address = <0x7200000>;
     entrypoint-offset = <0x4000>;
     xlat-granule = <0>; /* 4KiB */
     boot-order = <1>;

--- a/platform/manifest/tgt_tfa_fvp/v12/sp2_el0.dts
+++ b/platform/manifest/tgt_tfa_fvp/v12/sp2_el0.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -17,7 +17,7 @@
     execution-ctx-count = <1>;
     exception-level = <1>; /* S-EL0 */
     execution-state = <0>; /* AARCH64 */
-    load-address = <0x7100000>;
+    load-address = <0x7200000>;
     entrypoint-offset = <0x4000>;
     xlat-granule = <0>; /* 4KiB */
     boot-order = <1>;

--- a/platform/manifest/tgt_tfa_fvp/v12/sp3.dts
+++ b/platform/manifest/tgt_tfa_fvp/v12/sp3.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -20,7 +20,7 @@
     execution-ctx-count = <1>;
     exception-level = <2>; /* S-EL1 */
     execution-state = <0>; /* AARCH64 */
-    load-address = <0x7200000>;
+    load-address = <0x7400000>;
     entrypoint-offset = <0x4000>;
     xlat-granule = <0>; /* 4KiB */
     boot-order = <2>;

--- a/platform/manifest/tgt_tfa_fvp/v12/sp3_el0.dts
+++ b/platform/manifest/tgt_tfa_fvp/v12/sp3_el0.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -18,7 +18,7 @@
     execution-ctx-count = <1>;
     exception-level = <1>; /* S-EL0 */
     execution-state = <0>; /* AARCH64 */
-    load-address = <0x7200000>;
+    load-address = <0x7400000>;
     entrypoint-offset = <0x4000>;
     xlat-granule = <0>; /* 4KiB */
     boot-order = <2>;

--- a/platform/manifest/tgt_tfa_fvp/v12/sp4.dts
+++ b/platform/manifest/tgt_tfa_fvp/v12/sp4.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -20,7 +20,7 @@
     execution-ctx-count = <1>;
     exception-level = <2>; /* S-EL1 */
     execution-state = <0>; /* AARCH64 */
-    load-address = <0x7300000>;
+    load-address = <0x7600000>;
     entrypoint-offset = <0x4000>;
     xlat-granule = <0>; /* 4KiB */
     boot-order = <3>;

--- a/platform/manifest/tgt_tfa_fvp/v12/sp4_el0.dts
+++ b/platform/manifest/tgt_tfa_fvp/v12/sp4_el0.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -18,7 +18,7 @@
     execution-ctx-count = <1>;
     exception-level = <1>; /* S-EL0 */
     execution-state = <0>; /* AARCH64 */
-    load-address = <0x7300000>;
+    load-address = <0x7600000>;
     entrypoint-offset = <0x4000>;
     xlat-granule = <0>; /* 4KiB */
     boot-order = <3>;

--- a/tools/cmake/endpoints/sp1/image.ld.S
+++ b/tools/cmake/endpoints/sp1/image.ld.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -11,43 +11,48 @@ OUTPUT_FORMAT(elf64-littleaarch64)
 OUTPUT_ARCH(aarch64)
 ENTRY(val_entry)
 
+PHDRS
+{
+    text PT_LOAD FLAGS(RX);    /* Code, read + execute */
+    rodata PT_LOAD FLAGS(R);   /* Read-only data */
+    data PT_LOAD FLAGS(RW);    /* Writable data */
+    bss PT_LOAD FLAGS(RW);     /* BSS (no load, but RW in memory) */
+}
+
 SECTIONS
 {
     . = IMAGE_BASE;
 
     ASSERT(. == ALIGN(PLATFORM_PAGE_SIZE),
            "TEXT_START address is not aligned to PAGE_SIZE.")
+    
     .text : {
         __TEXT_START__ = .;
         *val_entry.S.o(.text*)
         *(.text*)
         . = NEXT(PLATFORM_PAGE_SIZE);
         __TEXT_END__ = .;
-    }
+    } :text
 
     .rodata : {
         . = ALIGN(PLATFORM_PAGE_SIZE);
         __RODATA_START__ = .;
         *(.rodata*)
-
         . = NEXT(PLATFORM_PAGE_SIZE);
         __RODATA_END__ = .;
-
-    }
+    } :rodata
 
     .data : {
         . = ALIGN(PLATFORM_PAGE_SIZE);
         __DATA_START__ = .;
         *(.data*)
-
         . = ALIGN(8);
         __GOT_START__ = .;
         *(.got)
         __GOT_END__ = .;
-
         . = NEXT(PLATFORM_PAGE_SIZE);
         __DATA_END__ = .;
-    }
+    } :data
 
     .bss (NOLOAD) : {
         . = ALIGN(PLATFORM_PAGE_SIZE);
@@ -56,5 +61,5 @@ SECTIONS
         *(COMMON)
         . = NEXT(PLATFORM_PAGE_SIZE);
         __BSS_END__ = .;
-    }
+    } :bss
 }

--- a/tools/cmake/endpoints/sp2/image.ld.S
+++ b/tools/cmake/endpoints/sp2/image.ld.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -11,43 +11,48 @@ OUTPUT_FORMAT(elf64-littleaarch64)
 OUTPUT_ARCH(aarch64)
 ENTRY(val_entry)
 
+PHDRS
+{
+    text PT_LOAD FLAGS(RX);    /* Code, read + execute */
+    rodata PT_LOAD FLAGS(R);   /* Read-only data */
+    data PT_LOAD FLAGS(RW);    /* Writable data */
+    bss PT_LOAD FLAGS(RW);     /* BSS (no load, but RW in memory) */
+}
+
 SECTIONS
 {
     . = IMAGE_BASE;
 
     ASSERT(. == ALIGN(PLATFORM_PAGE_SIZE),
            "TEXT_START address is not aligned to PAGE_SIZE.")
+    
     .text : {
         __TEXT_START__ = .;
         *val_entry.S.o(.text*)
         *(.text*)
         . = NEXT(PLATFORM_PAGE_SIZE);
         __TEXT_END__ = .;
-    }
+    } :text
 
     .rodata : {
         . = ALIGN(PLATFORM_PAGE_SIZE);
         __RODATA_START__ = .;
         *(.rodata*)
-
         . = NEXT(PLATFORM_PAGE_SIZE);
         __RODATA_END__ = .;
-
-    }
+    } :rodata
 
     .data : {
         . = ALIGN(PLATFORM_PAGE_SIZE);
         __DATA_START__ = .;
         *(.data*)
-
         . = ALIGN(8);
         __GOT_START__ = .;
         *(.got)
         __GOT_END__ = .;
-
         . = NEXT(PLATFORM_PAGE_SIZE);
         __DATA_END__ = .;
-    }
+    } :data
 
     .bss (NOLOAD) : {
         . = ALIGN(PLATFORM_PAGE_SIZE);
@@ -56,5 +61,5 @@ SECTIONS
         *(COMMON)
         . = NEXT(PLATFORM_PAGE_SIZE);
         __BSS_END__ = .;
-    }
+    } :bss
 }

--- a/tools/cmake/endpoints/sp3/image.ld.S
+++ b/tools/cmake/endpoints/sp3/image.ld.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -11,43 +11,48 @@ OUTPUT_FORMAT(elf64-littleaarch64)
 OUTPUT_ARCH(aarch64)
 ENTRY(val_entry)
 
+PHDRS
+{
+    text PT_LOAD FLAGS(RX);    /* Code, read + execute */
+    rodata PT_LOAD FLAGS(R);   /* Read-only data */
+    data PT_LOAD FLAGS(RW);    /* Writable data */
+    bss PT_LOAD FLAGS(RW);     /* BSS (no load, but RW in memory) */
+}
+
 SECTIONS
 {
     . = IMAGE_BASE;
 
     ASSERT(. == ALIGN(PLATFORM_PAGE_SIZE),
            "TEXT_START address is not aligned to PAGE_SIZE.")
+    
     .text : {
         __TEXT_START__ = .;
         *val_entry.S.o(.text*)
         *(.text*)
         . = NEXT(PLATFORM_PAGE_SIZE);
         __TEXT_END__ = .;
-    }
+    } :text
 
     .rodata : {
         . = ALIGN(PLATFORM_PAGE_SIZE);
         __RODATA_START__ = .;
         *(.rodata*)
-
         . = NEXT(PLATFORM_PAGE_SIZE);
         __RODATA_END__ = .;
-
-    }
+    } :rodata
 
     .data : {
         . = ALIGN(PLATFORM_PAGE_SIZE);
         __DATA_START__ = .;
         *(.data*)
-
         . = ALIGN(8);
         __GOT_START__ = .;
         *(.got)
         __GOT_END__ = .;
-
         . = NEXT(PLATFORM_PAGE_SIZE);
         __DATA_END__ = .;
-    }
+    } :data
 
     .bss (NOLOAD) : {
         . = ALIGN(PLATFORM_PAGE_SIZE);
@@ -56,5 +61,5 @@ SECTIONS
         *(COMMON)
         . = NEXT(PLATFORM_PAGE_SIZE);
         __BSS_END__ = .;
-    }
+    } :bss
 }

--- a/tools/cmake/endpoints/sp4/image.ld.S
+++ b/tools/cmake/endpoints/sp4/image.ld.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -11,43 +11,48 @@ OUTPUT_FORMAT(elf64-littleaarch64)
 OUTPUT_ARCH(aarch64)
 ENTRY(val_entry)
 
+PHDRS
+{
+    text PT_LOAD FLAGS(RX);    /* Code, read + execute */
+    rodata PT_LOAD FLAGS(R);   /* Read-only data */
+    data PT_LOAD FLAGS(RW);    /* Writable data */
+    bss PT_LOAD FLAGS(RW);     /* BSS (no load, but RW in memory) */
+}
+
 SECTIONS
 {
     . = IMAGE_BASE;
 
     ASSERT(. == ALIGN(PLATFORM_PAGE_SIZE),
            "TEXT_START address is not aligned to PAGE_SIZE.")
+    
     .text : {
         __TEXT_START__ = .;
         *val_entry.S.o(.text*)
         *(.text*)
         . = NEXT(PLATFORM_PAGE_SIZE);
         __TEXT_END__ = .;
-    }
+    } :text
 
     .rodata : {
         . = ALIGN(PLATFORM_PAGE_SIZE);
         __RODATA_START__ = .;
         *(.rodata*)
-
         . = NEXT(PLATFORM_PAGE_SIZE);
         __RODATA_END__ = .;
-
-    }
+    } :rodata
 
     .data : {
         . = ALIGN(PLATFORM_PAGE_SIZE);
         __DATA_START__ = .;
         *(.data*)
-
         . = ALIGN(8);
         __GOT_START__ = .;
         *(.got)
         __GOT_END__ = .;
-
         . = NEXT(PLATFORM_PAGE_SIZE);
         __DATA_END__ = .;
-    }
+    } :data
 
     .bss (NOLOAD) : {
         . = ALIGN(PLATFORM_PAGE_SIZE);
@@ -56,5 +61,5 @@ SECTIONS
         *(COMMON)
         . = NEXT(PLATFORM_PAGE_SIZE);
         __BSS_END__ = .;
-    }
+    } :bss
 }

--- a/tools/cmake/endpoints/vm1/image.ld.S
+++ b/tools/cmake/endpoints/vm1/image.ld.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -11,43 +11,48 @@ OUTPUT_FORMAT(elf64-littleaarch64)
 OUTPUT_ARCH(aarch64)
 ENTRY(val_entry)
 
+PHDRS
+{
+    text PT_LOAD FLAGS(RX);    /* Code, read + execute */
+    rodata PT_LOAD FLAGS(R);   /* Read-only data */
+    data PT_LOAD FLAGS(RW);    /* Writable data */
+    bss PT_LOAD FLAGS(RW);     /* BSS (no load, but RW in memory) */
+}
+
 SECTIONS
 {
     . = IMAGE_BASE;
 
     ASSERT(. == ALIGN(PLATFORM_PAGE_SIZE),
            "TEXT_START address is not aligned to PAGE_SIZE.")
+    
     .text : {
         __TEXT_START__ = .;
         *val_entry.S.o(.text*)
         *(.text*)
         . = NEXT(PLATFORM_PAGE_SIZE);
         __TEXT_END__ = .;
-    }
+    } :text
 
     .rodata : {
         . = ALIGN(PLATFORM_PAGE_SIZE);
         __RODATA_START__ = .;
         *(.rodata*)
-
         . = NEXT(PLATFORM_PAGE_SIZE);
         __RODATA_END__ = .;
-
-    }
+    } :rodata
 
     .data : {
         . = ALIGN(PLATFORM_PAGE_SIZE);
         __DATA_START__ = .;
         *(.data*)
-
         . = ALIGN(8);
         __GOT_START__ = .;
         *(.got)
         __GOT_END__ = .;
-
         . = NEXT(PLATFORM_PAGE_SIZE);
         __DATA_END__ = .;
-    }
+    } :data
 
     .bss (NOLOAD) : {
         . = ALIGN(PLATFORM_PAGE_SIZE);
@@ -56,5 +61,5 @@ SECTIONS
         *(COMMON)
         . = NEXT(PLATFORM_PAGE_SIZE);
         __BSS_END__ = .;
-    }
+    } :bss
 }

--- a/tools/cmake/endpoints/vm2/image.ld.S
+++ b/tools/cmake/endpoints/vm2/image.ld.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -11,43 +11,48 @@ OUTPUT_FORMAT(elf64-littleaarch64)
 OUTPUT_ARCH(aarch64)
 ENTRY(val_entry)
 
+PHDRS
+{
+    text PT_LOAD FLAGS(RX);    /* Code, read + execute */
+    rodata PT_LOAD FLAGS(R);   /* Read-only data */
+    data PT_LOAD FLAGS(RW);    /* Writable data */
+    bss PT_LOAD FLAGS(RW);     /* BSS (no load, but RW in memory) */
+}
+
 SECTIONS
 {
     . = IMAGE_BASE;
 
     ASSERT(. == ALIGN(PLATFORM_PAGE_SIZE),
            "TEXT_START address is not aligned to PAGE_SIZE.")
+    
     .text : {
         __TEXT_START__ = .;
         *val_entry.S.o(.text*)
         *(.text*)
         . = NEXT(PLATFORM_PAGE_SIZE);
         __TEXT_END__ = .;
-    }
+    } :text
 
     .rodata : {
         . = ALIGN(PLATFORM_PAGE_SIZE);
         __RODATA_START__ = .;
         *(.rodata*)
-
         . = NEXT(PLATFORM_PAGE_SIZE);
         __RODATA_END__ = .;
-
-    }
+    } :rodata
 
     .data : {
         . = ALIGN(PLATFORM_PAGE_SIZE);
         __DATA_START__ = .;
         *(.data*)
-
         . = ALIGN(8);
         __GOT_START__ = .;
         *(.got)
         __GOT_END__ = .;
-
         . = NEXT(PLATFORM_PAGE_SIZE);
         __DATA_END__ = .;
-    }
+    } :data
 
     .bss (NOLOAD) : {
         . = ALIGN(PLATFORM_PAGE_SIZE);
@@ -56,5 +61,5 @@ SECTIONS
         *(COMMON)
         . = NEXT(PLATFORM_PAGE_SIZE);
         __BSS_END__ = .;
-    }
+    } :bss
 }

--- a/tools/cmake/endpoints/vm3/image.ld.S
+++ b/tools/cmake/endpoints/vm3/image.ld.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -11,43 +11,48 @@ OUTPUT_FORMAT(elf64-littleaarch64)
 OUTPUT_ARCH(aarch64)
 ENTRY(val_entry)
 
+PHDRS
+{
+    text PT_LOAD FLAGS(RX);    /* Code, read + execute */
+    rodata PT_LOAD FLAGS(R);   /* Read-only data */
+    data PT_LOAD FLAGS(RW);    /* Writable data */
+    bss PT_LOAD FLAGS(RW);     /* BSS (no load, but RW in memory) */
+}
+
 SECTIONS
 {
     . = IMAGE_BASE;
 
     ASSERT(. == ALIGN(PLATFORM_PAGE_SIZE),
            "TEXT_START address is not aligned to PAGE_SIZE.")
+    
     .text : {
         __TEXT_START__ = .;
         *val_entry.S.o(.text*)
         *(.text*)
         . = NEXT(PLATFORM_PAGE_SIZE);
         __TEXT_END__ = .;
-    }
+    } :text
 
     .rodata : {
         . = ALIGN(PLATFORM_PAGE_SIZE);
         __RODATA_START__ = .;
         *(.rodata*)
-
         . = NEXT(PLATFORM_PAGE_SIZE);
         __RODATA_END__ = .;
-
-    }
+    } :rodata
 
     .data : {
         . = ALIGN(PLATFORM_PAGE_SIZE);
         __DATA_START__ = .;
         *(.data*)
-
         . = ALIGN(8);
         __GOT_START__ = .;
         *(.got)
         __GOT_END__ = .;
-
         . = NEXT(PLATFORM_PAGE_SIZE);
         __DATA_END__ = .;
-    }
+    } :data
 
     .bss (NOLOAD) : {
         . = ALIGN(PLATFORM_PAGE_SIZE);
@@ -56,5 +61,5 @@ SECTIONS
         *(COMMON)
         . = NEXT(PLATFORM_PAGE_SIZE);
         __BSS_END__ = .;
-    }
+    } :bss
 }

--- a/tools/cmake/toolchain/linker.cmake
+++ b/tools/cmake/toolchain/linker.cmake
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2021, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -15,7 +15,7 @@ set(GNUARM_OBJCOPY "${CROSS_COMPILE}objcopy" CACHE FILEPATH "The GNUARM objcopy"
 set(GNUARM_OBJDUMP "${CROSS_COMPILE}objdump" CACHE FILEPATH "The GNUARM objdump" FORCE)
 
 if(${ENABLE_PIE})
-    set(LINKER_PIE_SWITCH "-pie --no-dynamic-linker")
+    set(LINKER_PIE_SWITCH "-pie" "--no-dynamic-linker")
 else()
     set(LINKER_PIE_SWITCH "")
 endif()
@@ -26,7 +26,7 @@ else()
     set(LINKER_DEBUG_OPTIONS "")
 endif()
 
-set(GNUARM_LINKER_FLAGS "--fatal-warnings  ${LINKER_PIE_SWITCH} ${LINKER_DEBUG_OPTIONS} -O1 --gc-sections --build-id=none")
+set(GNUARM_LINKER_FLAGS "--fatal-warnings"  ${LINKER_PIE_SWITCH} ${LINKER_DEBUG_OPTIONS} "-O1" "--gc-sections" "--build-id=none")
 set(GNUARM_OBJDUMP_FLAGS    "-dSx")
 set(GNUARM_OBJCOPY_FLAGS    "-Obinary")
 
@@ -42,7 +42,7 @@ function (create_executable EXE_NAME)
 
     # Link the objects
     add_custom_command(OUTPUT ${EXE_NAME}.elf
-                    COMMAND ${GNUARM_LINKER} ${CMAKE_LINKER_FLAGS} -T ${SCATTER_OUTPUT_FILE} -o ${EXE_NAME}.elf ${VAL_LIB}.a ${PAL_LIB}.a ${TEST_LIB}.a ${VAL_LIB}.a ${PAL_LIB}.a ${PAL_OBJ_LIST}
+                    COMMAND ${GNUARM_LINKER} ${CMAKE_LINKER_FLAGS} ${GNUARM_LINKER_FLAGS} -T ${SCATTER_OUTPUT_FILE} -o ${EXE_NAME}.elf ${VAL_LIB}.a ${PAL_LIB}.a ${TEST_LIB}.a ${VAL_LIB}.a ${PAL_LIB}.a ${PAL_OBJ_LIST}
                     DEPENDS Process-linker-script-${EXE_NAME})
     add_custom_target(${EXE_NAME}_elf ALL DEPENDS ${EXE_NAME}.elf)
 

--- a/val/src/aarch64/val_entry.S
+++ b/val/src/aarch64/val_entry.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -117,19 +117,26 @@ pie_fixup:
     bl    fix_symbol_table
 
     /* Setup the stack pointer to call C entry */
-    adr    x0, stacks_end
+    adrp   x0, stacks_end
+    add    x0, x0, :lo12:stacks_end
     mov    sp, x0
 
-   /* Clear BSS */
-   adr x2, val_image_load_offset
-   ldr x2, [x2]
-   adr x0, bss_start_addr
-   ldr x0, [x0]
-   add x0, x0, x2
-   adr x1, bss_end_addr
-   ldr x1, [x1]
-   add x1, x1, x2
-   sub x1, x1, x0
+    /* Clear BSS */
+    adrp   x2, val_image_load_offset
+    add    x2, x2, :lo12:val_image_load_offset
+    ldr    x2, [x2]
+
+    adrp   x0, bss_start_addr
+    add    x0, x0, :lo12:bss_start_addr
+    ldr    x0, [x0]
+    add    x0, x0, x2
+
+    adrp   x1, bss_end_addr
+    add    x1, x1, :lo12:bss_end_addr
+    ldr    x1, [x1]
+    add    x1, x1, x2
+
+    sub    x1, x1, x0
 2:
    stp xzr, xzr, [x0]
    add x0, x0, #16

--- a/val/src/aarch64/val_entry_el0.S
+++ b/val/src/aarch64/val_entry_el0.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -48,8 +48,9 @@ stacks_end:
 
 val_entry:
 
-    /* Setup the stack pointer. */
-    adr    x0, stacks_end
+    /* Setup the stack pointer to call C entry */
+    adrp   x0, stacks_end
+    add    x0, x0, :lo12:stacks_end
     mov    sp, x0
 
     /* RODATA+DATA+BSS marked RW so relocations can succeed. */


### PR DESCRIPTION
- PHDRs were defined in linker scripts to separate text, rodata, data, and bss into distinct segments with correct memory permissions.
- A bug in linker. CMake was fixed to ensure linker flags were properly propagated during ELF linking.
- Memory sizes were increased, and load addresses were adjusted in SP manifest files to prevent overlaps and ensure sufficient space.
- Assembly code was refactored to use adrp + add for PIE compatibility and reliable symbol address resolution.


Change-Id: I824d77f2af4d3225487c097b94434b931e33e737