### PR TITLE
Per-vCPU Notification Test Updates

### DIFF
--- a/platform/pal_baremetal/tgt_tfa_fvp/inc/pal_config_def.h
+++ b/platform/pal_baremetal/tgt_tfa_fvp/inc/pal_config_def.h
@@ -187,6 +187,9 @@
  */
 #define PLATFORM_NO_OF_CPUS 8
 
+/* Per-vCPU Notification Support */
+#define PLATFORM_PER_VCPU_NOTIFICATION_SUPPORT 0
+
 #ifndef __ASSEMBLER__
 extern uint8_t pal_misc_buffer[256];
 #define PLATFORM_SHARED_REGION_BASE (void*)pal_misc_buffer

--- a/test/v1.1/notifications/notification_set/notification_set_client.c
+++ b/test/v1.1/notifications/notification_set/notification_set_client.c
@@ -20,7 +20,10 @@ uint32_t notification_set_client(uint32_t test_run_data)
     uint64_t notifications_bm_global = FFA_NOTIFICATION(12);
     uint64_t notifications_bm_pcpu = FFA_NOTIFICATION(13);
     uint64_t notifications_bm_invalid = FFA_NOTIFICATION(16);
+
+#if (PLATFORM_PER_VCPU_NOTIFICATION_SUPPORT == 1)
     ffa_endpoint_id_t receiver_vcpuid = 0x2;
+#endif
 
 
     val_memset(&payload, 0, sizeof(ffa_args_t));
@@ -77,6 +80,8 @@ uint32_t notification_set_client(uint32_t test_run_data)
         goto bitmap_destroy;
     }
 
+
+#if (PLATFORM_PER_VCPU_NOTIFICATION_SUPPORT == 1)
     /* Per-vCPU notification flag = b'0 and Receiver vCPU ID != 0 */
     val_memset(&payload, 0, sizeof(ffa_args_t));
     payload.arg1 = ((uint32_t)sender << 16) | recipient;
@@ -121,6 +126,7 @@ uint32_t notification_set_client(uint32_t test_run_data)
         status = VAL_ERROR_POINT(7);
         goto bitmap_destroy;
     }
+#endif
 
     /* DENIED: Sender not permitted to signal the notification to the receiver */
     val_memset(&payload, 0, sizeof(ffa_args_t));

--- a/test/v1.1/notifications/sp_signals_vm_sp/sp_signals_vm_sp_server.c
+++ b/test/v1.1/notifications/sp_signals_vm_sp/sp_signals_vm_sp_server.c
@@ -61,7 +61,9 @@ static uint32_t sp1_entry_func(ffa_args_t args)
     ffa_endpoint_id_t receiver = (args.arg1 >> 16) & 0xffff;
     ffa_endpoint_id_t receiver_1 = val_get_endpoint_id(SP2);
     ffa_notification_bitmap_t notifications_bitmap_1;
+#if (PLATFORM_PER_VCPU_NOTIFICATION_SUPPORT == 1)
     ffa_notification_bitmap_t notifications_bitmap_2;
+#endif
     ffa_notification_bitmap_t notifications_bitmap_3;
     uint32_t flags;
 
@@ -81,7 +83,9 @@ static uint32_t sp1_entry_func(ffa_args_t args)
     VM1 per-vCPU Notification - bitmap_2
     SP2 Global Notification   - bitmap_3 */
     notifications_bitmap_1 = payload.arg3;
+#if (PLATFORM_PER_VCPU_NOTIFICATION_SUPPORT == 1)
     notifications_bitmap_2 = payload.arg4;
+#endif
     notifications_bitmap_3 = payload.arg5;
 
     /* Register T-WD handler for Secure Interrupt */
@@ -125,14 +129,14 @@ static uint32_t sp1_entry_func(ffa_args_t args)
     {
         goto free_interrupt;
     }
-
+#if (PLATFORM_PER_VCPU_NOTIFICATION_SUPPORT == 1)
     flags = FFA_NOTIFICATIONS_FLAG_PER_VCPU | FFA_NOTIFICATIONS_FLAG_DELAY_SRI;
     status = notification_set_helper(notifications_bitmap_2, flags, sender, receiver);
     if (status)
     {
         goto free_interrupt;
     }
-
+#endif
     flags = FFA_NOTIFICATIONS_FLAG_DELAY_SRI;
     status = notification_set_helper(notifications_bitmap_3, flags, sender, receiver_1);
     if (status)

--- a/test/v1.1/notifications/vm_to_sp_notification_pcpu/vm_to_sp_notification_pcpu_client.c
+++ b/test/v1.1/notifications/vm_to_sp_notification_pcpu/vm_to_sp_notification_pcpu_client.c
@@ -32,6 +32,11 @@ uint32_t vm_to_sp_notification_pcpu_client(uint32_t test_run_data)
 #endif
     uint64_t notifications_bitmap = FFA_NOTIFICATION(12);
 
+#if (PLATFORM_PER_VCPU_NOTIFICATION_SUPPORT == 0)
+    LOG(WARN, "No Support for per vCPU Notification\n", 0);
+    return VAL_SKIP_CHECK;
+#endif
+
     val_memset(&payload, 0, sizeof(ffa_args_t));
     payload.arg1 = FFA_FEATURE_SRI;
     val_ffa_features(&payload);

--- a/test/v1.1/notifications/vm_to_sp_notification_pcpu_el0/vm_to_sp_notification_pcpu_el0_client.c
+++ b/test/v1.1/notifications/vm_to_sp_notification_pcpu_el0/vm_to_sp_notification_pcpu_el0_client.c
@@ -32,6 +32,11 @@ uint32_t vm_to_sp_notification_pcpu_el0_client(uint32_t test_run_data)
 #endif
     uint64_t notifications_bitmap = FFA_NOTIFICATION(12);
 
+#if (PLATFORM_PER_VCPU_NOTIFICATION_SUPPORT == 0)
+   LOG(WARN, "No Support for per vCPU Notification\n", 0);
+   return VAL_SKIP_CHECK;
+#endif
+
     val_memset(&payload, 0, sizeof(ffa_args_t));
     payload.arg1 = FFA_FEATURE_SRI;
     val_ffa_features(&payload);


### PR DESCRIPTION
- Add PLATFORM_VCPU_NOTIFICATION_SUPPORT flag support for per vCPU Notification
- The per vCPU Notification will only run if the flag is set default 0
