### PR TITLE
Update partition info structure and add common parser

### DIFF
--- a/test/v1.0/direct_messaging/ffa_direct_message_error/ffa_direct_message_error_client.c
+++ b/test/v1.0/direct_messaging/ffa_direct_message_error/ffa_direct_message_error_client.c
@@ -59,8 +59,9 @@ uint32_t ffa_direct_message_error_client(uint32_t test_run_data)
         goto rx_release;
     }
 
-    info = (ffa_partition_info_t *)rx_buff;
     count = (uint32_t)payload.arg2;
+    info = val_malloc(count * sizeof(ffa_partition_info_t));
+    val_ffa_partition_descriptor_info_parser(info, rx_buff, payload.arg3, count);
 
     LOG(DBG, "Partition info count %x\n", (uint32_t)payload.arg2);
 

--- a/test/v1.0/direct_messaging/ffa_direct_message_error1/ffa_direct_message_error1_client.c
+++ b/test/v1.0/direct_messaging/ffa_direct_message_error1/ffa_direct_message_error1_client.c
@@ -59,8 +59,10 @@ uint32_t ffa_direct_message_error1_client(uint32_t test_run_data)
         goto rx_release;
     }
 
-    info = (ffa_partition_info_t *)rx_buff;
     count = (uint32_t)payload.arg2;
+    info = val_malloc(count * sizeof(ffa_partition_info_t));
+    val_ffa_partition_descriptor_info_parser(info, rx_buff, payload.arg3, count);
+
 
     LOG(DBG, "Partition info count %x\n", (uint32_t)payload.arg2);
 

--- a/test/v1.0/indirect_messaging/ffa_msg_send_error/ffa_msg_send_error_client.c
+++ b/test/v1.0/indirect_messaging/ffa_msg_send_error/ffa_msg_send_error_client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021-2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -64,8 +64,9 @@ uint32_t ffa_msg_send_error_client(uint32_t test_run_data)
         goto rxtx_unmap;
     }
 
-    info = (ffa_partition_info_t *)rx_buff;
     count = (uint32_t)payload.arg2;
+    info = val_malloc(count * sizeof(ffa_partition_info_t));
+    val_ffa_partition_descriptor_info_parser(info, rx_buff, payload.arg3, count);
 
     LOG(DBG, "Partition info count %x\n", (uint32_t)payload.arg2);
 

--- a/test/v1.0/setup_discovery/ffa_partition_info_get/ffa_partition_info_get_client.c
+++ b/test/v1.0/setup_discovery/ffa_partition_info_get/ffa_partition_info_get_client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021-2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -169,7 +169,8 @@ static uint32_t ffa_partition_info_helper(void *rx_buff, const uint32_t uuid[4],
 
     if (flags == FFA_PARTITION_INFO_FLAG_RETDESC)
     {
-        info = (ffa_partition_info_t *)rx_buff;
+        info = val_malloc(payload.arg2 * sizeof(ffa_partition_info_t));
+        val_ffa_partition_descriptor_info_parser(info, rx_buff, payload.arg3, payload.arg2);
         for (i = 0; i < expected_count; i++)
         {
             if (!is_matching_endpoint_found(&expected[i], &info[0], payload.arg2))

--- a/test/v1.2/setup_discovery/ffa_partition_info_get_lsp/ffa_partition_info_get_lsp_client.c
+++ b/test/v1.2/setup_discovery/ffa_partition_info_get_lsp/ffa_partition_info_get_lsp_client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -14,6 +14,15 @@
 /* SPMD Logical SP currently only supports sending direct message. */
 #define SPMD_PARTITION_PROPERTIES FFA_DIRECT_REQUEST_SEND | FFA_PARTITION_EXEC_STATE_ARCH64
 
+/* Endpoint match status:
+ * FAIL     - ID found but data mismatch
+ * PASS     - ID found and data matches
+ * CONTINUE - ID not found, keep checking
+ */
+#define EP_MATCH_FAIL      0
+#define EP_MATCH_PASS      1
+#define EP_MATCH_CONTINUE  2
+
 static val_endpoint_info_t lsp_info = {
         "SP1",
         .is_valid    = VAL_PARTITION_PRESENT,
@@ -26,15 +35,20 @@ static val_endpoint_info_t lsp_info = {
         SPMD_LP_UUID,
 };
 
-static ffa_args_t ffa_partition_info_get_regs(const uint32_t uuid[4])
+static ffa_args_t ffa_partition_info_get_regs(const uint32_t uuid[4], uint64_t start_index_and_tag)
 {
     LOG(DBG, "uuid[0] %x, uuid[1] %x uuid[2] %x uuid[3] %x\n", uuid[0], uuid[1], uuid[2], uuid[3]);
     ffa_args_t payload;
     val_memset(&payload, 0, sizeof(ffa_args_t));
 
+    if (start_index_and_tag) {
+        start_index_and_tag = start_index_and_tag + 1;
+     }
+
     payload.arg1 = ((uint64_t)uuid[1]<<32) | uuid[0];
     payload.arg2 = ((uint64_t)uuid[3]<<32) | uuid[2];
-    LOG(DBG, "arg1 %lx, arg2 %lx\n", payload.arg1, payload.arg2);
+    payload.arg3 = start_index_and_tag;
+    LOG(DBG, "arg1 %lx, arg2 %lx, arg3 %lx\n", payload.arg1, payload.arg2, payload.arg3);
     val_ffa_partition_info_get_regs(&payload);
 
     return payload;
@@ -59,7 +73,7 @@ static uint32_t is_matching_endpoint_found(const val_endpoint_info_t *expected_e
             LOG(ERROR, "Data mismatch for endpoint id: info.id=%x\n", expected_ep[0].id);
             LOG(ERROR, "expected_ep[0].ec_count=%x, info.exec_context=%x\n",
                 expected_ep[0].ec_count,  info_get[i].exec_context);
-            return 0;
+            return EP_MATCH_FAIL;
         }
 
         if (expected_ep[0].ep_properties != info_get[i].properties)
@@ -68,13 +82,12 @@ static uint32_t is_matching_endpoint_found(const val_endpoint_info_t *expected_e
                 expected_ep[0].id, 0);
             LOG(ERROR, "expected_ep[0].ep_properties=%x, info.properties=%x\n",
                 expected_ep[0].ep_properties,  info_get[i].properties);
-            return 0;
+            return EP_MATCH_FAIL;
         }
 
-        return 1;
+        return EP_MATCH_PASS;
     }
-    LOG(ERROR, "Endpoint-id=%x info not found\n", expected_ep[0].id);
-    return 0;
+    return EP_MATCH_CONTINUE; /* Not all points are checked it will continue */
 }
 
 static uint32_t ffa_partition_info_helper(const uint32_t uuid[4],
@@ -84,19 +97,43 @@ static uint32_t ffa_partition_info_helper(const uint32_t uuid[4],
     ffa_args_t payload;
     uint32_t status = VAL_SUCCESS;
     ffa_partition_info_t *info;
+    uint64_t info_get_count, info_get_descriptor_size;
+    uint64_t current_index = 0, last_index = 0;
+    uint32_t current_matching_status = 2;
 
-    val_memset(&payload, 0, sizeof(ffa_args_t));
-    payload = ffa_partition_info_get_regs(uuid);
-    if (payload.fid == FFA_ERROR_32)
-    {
-        LOG(ERROR, "partition info get failed fid=0x%x, err=0x%x\n", payload.fid, payload.arg2);
-        return VAL_ERROR_POINT(5);
+    while ((count == 1) || ((current_index + 1) < count)) {
+
+        val_memset(&payload, 0, sizeof(ffa_args_t));
+        payload = ffa_partition_info_get_regs(uuid, current_index);
+        if (payload.fid == FFA_ERROR_32)
+        {
+            LOG(ERROR, "partition info get failed fid=0x%x, err=0x%x\n",
+                                                 payload.fid, payload.arg2);
+            return VAL_ERROR_POINT(5);
+        }
+
+        current_index = (payload.arg2 >> 16 & 0xffff);
+        info_get_descriptor_size = (payload.arg2 >> 48 & 0xffff);
+        info_get_count = (current_index - last_index) + 1;
+        info = val_malloc(info_get_count * sizeof(ffa_partition_info_t));
+        val_ffa_partition_descriptor_info_parser(info, &payload.arg3,
+                                       info_get_descriptor_size, info_get_count);
+
+        current_matching_status = is_matching_endpoint_found(&expected[0],
+                                                   &info[0], info_get_count);
+        if (!(current_matching_status)) {
+            status = VAL_ERROR_POINT(9);
+            break;
+        }
+
+        if ((count == 1) && (current_matching_status == 1))
+           break;
+
+        last_index = current_index;
     }
 
-    info = (ffa_partition_info_t *)&payload.arg3;
-
-    if (!is_matching_endpoint_found(&expected[0], &info[0], count))
-    {
+    if (current_matching_status == 2 && (current_index + 1 == count)) {
+        LOG(ERROR, "Endpoint-id=%x info not found\n", expected[0].id);
         status = VAL_ERROR_POINT(9);
     }
 

--- a/test/v1.2/setup_discovery/ffa_partition_info_get_regs/ffa_partition_info_get_regs_client.c
+++ b/test/v1.2/setup_discovery/ffa_partition_info_get_regs/ffa_partition_info_get_regs_client.c
@@ -19,20 +19,32 @@
 #define EP_ID4 SP4
 #endif
 
+/* Endpoint match status:
+ * FAIL     - ID found but data mismatch
+ * PASS     - ID found and data matches
+ */
+#define EP_MATCH_FAIL      0
+#define EP_MATCH_PASS      1
+
 /**
  * FFA_INFO_GET_REGS Helper
  *
  * Returns info get reg Get arg fescriptor
  */
-static ffa_args_t ffa_partition_info_get_regs(const uint32_t uuid[4])
+static ffa_args_t ffa_partition_info_get_regs(const uint32_t uuid[4], uint64_t start_index_and_tag)
 {
     LOG(DBG, "uuid[0] %x, uuid[1] %x uuid[2] %x uuid[3] %x\n", uuid[0], uuid[1], uuid[2], uuid[3]);
     ffa_args_t payload;
     val_memset(&payload, 0, sizeof(ffa_args_t));
 
+    if (start_index_and_tag) {
+        start_index_and_tag = start_index_and_tag + 1;
+    }
+
     payload.arg1 = ((uint64_t)uuid[1]<<32) | uuid[0];
     payload.arg2 = ((uint64_t)uuid[3]<<32) | uuid[2];
-    LOG(DBG, "arg1 %lx, arg2 %lx\n", payload.arg1, payload.arg2);
+    payload.arg3 = start_index_and_tag;
+    LOG(DBG, "arg1 %lx, arg2 %lx, arg3 %lx\n", payload.arg1, payload.arg2, payload.arg3);
     val_ffa_partition_info_get_regs(&payload);
 
     return payload;
@@ -50,7 +62,7 @@ static uint32_t ffa_partition_info_get_regs_invalid_uuid_test(void)
     uint32_t status = VAL_SUCCESS;
 
     /* FFA_INFO_GET_REG call with invalid UUID */
-    ffa_args_t payload = ffa_partition_info_get_regs(uuid);
+    ffa_args_t payload = ffa_partition_info_get_regs(uuid, 0);
 
     if ((payload.fid != FFA_ERROR_32) || (payload.arg2 != FFA_ERROR_INVALID_PARAMETERS))
     {
@@ -62,7 +74,7 @@ static uint32_t ffa_partition_info_get_regs_invalid_uuid_test(void)
     LOG(DBG, "UUID %x %x %x %x\n", uuid[0], uuid[1], uuid[2], uuid[3]);
 
     /* FFA_INFO_GET_REG call with NULL UUID */
-    payload = ffa_partition_info_get_regs(null_uuid);
+    payload = ffa_partition_info_get_regs(null_uuid, 0);
     if (payload.fid == FFA_ERROR_32)
     {
         LOG(ERROR, "Invalid fid received, fid=0x%x\n", payload.fid);
@@ -96,7 +108,7 @@ static uint32_t is_matching_endpoint_found(const val_endpoint_info_t *expected_e
             LOG(ERROR, "Data mismatch for endpoint id: info.id=%x\n", expected_ep[0].id);
             LOG(ERROR, "expected_ep[0].ec_count=%x, info.exec_context=%x\n",
                 expected_ep[0].ec_count,  info_get[i].exec_context);
-            return 0;
+            return EP_MATCH_FAIL;
         }
 
 #if (PLATFORM_SP_EL == 1)
@@ -108,7 +120,7 @@ static uint32_t is_matching_endpoint_found(const val_endpoint_info_t *expected_e
                     expected_ep[0].id, 0);
                 LOG(ERROR, "expected_ep[0].ep_properties=%x, info.properties=%x\n",
                     expected_ep[0].ep_properties,  info_get[i].properties);
-                return 0;
+                return EP_MATCH_FAIL;
             }
         }
         else
@@ -120,13 +132,13 @@ static uint32_t is_matching_endpoint_found(const val_endpoint_info_t *expected_e
                     expected_ep[0].id);
                 LOG(ERROR, "expected_ep[0].ep_properties=%x, info.properties=%x\n",
                     expected_ep[0].ep_properties,  info_get[i].properties);
-                return 0;
+                return EP_MATCH_FAIL;
             }
         }
-        return 1;
+        return EP_MATCH_PASS;
     }
     LOG(ERROR, "Endpoint-id=%x info not found\n", expected_ep[0].id);
-    return 0;
+    return EP_MATCH_FAIL;
 }
 
 static uint32_t ffa_partition_info_helper(const uint32_t uuid[4],
@@ -136,23 +148,41 @@ static uint32_t ffa_partition_info_helper(const uint32_t uuid[4],
     ffa_args_t payload;
     uint32_t status = VAL_SUCCESS;
     ffa_partition_info_t *info;
-    uint32_t i;
+    uint32_t i = 0;
+    uint64_t info_get_count, info_get_descriptor_size;
+    uint64_t current_index = 0, last_index = 0;
+    uint32_t current_matching_status = 1;
 
-    val_memset(&payload, 0, sizeof(ffa_args_t));
-    payload = ffa_partition_info_get_regs(uuid);
-    if (payload.fid == FFA_ERROR_32)
-    {
-        LOG(ERROR, "partition info get failed fid=0x%x, err=0x%x\n", payload.fid, payload.arg2);
-        return VAL_ERROR_POINT(5);
-    }
-
-    info = (ffa_partition_info_t *)&payload.arg3;
-    for (i = 0; i < count; i++)
-    {
-        if (!is_matching_endpoint_found(&expected[i], &info[0], count))
+    while ((count == 1) || ((current_index + 1) < count)) {
+        val_memset(&payload, 0, sizeof(ffa_args_t));
+        payload = ffa_partition_info_get_regs(uuid, current_index);
+        if (payload.fid == FFA_ERROR_32)
         {
-            status = VAL_ERROR_POINT(9);
+            LOG(ERROR, "partition info get failed fid=0x%x, err=0x%x\n",
+                                               payload.fid, payload.arg2);
+            return VAL_ERROR_POINT(5);
         }
+
+        current_index = (payload.arg2 >> 16 & 0xffff);
+        info_get_descriptor_size = (payload.arg2 >> 48 & 0xffff);
+        info_get_count = (current_index - last_index) + 1;
+        info = val_malloc(info_get_count * sizeof(ffa_partition_info_t));
+        val_ffa_partition_descriptor_info_parser(info, &payload.arg3,
+                                       info_get_descriptor_size, info_get_count);
+
+        while ((i <= current_index) && (i < count)) {
+            current_matching_status = is_matching_endpoint_found(&expected[i],
+                                                    &info[0], info_get_count);
+
+            if (!(current_matching_status))
+                status = VAL_ERROR_POINT(9);
+            i++;
+        }
+
+        if (count == 1)
+            break;
+
+        last_index = current_index;
     }
     return status;
 }

--- a/val/inc/val_ffa.h
+++ b/val/inc/val_ffa.h
@@ -150,6 +150,11 @@ static const ffa_func_id_t ffa_supported_fids[] = {
 
 #define VAL_EXTRACT_BITS(data, start, end) ((data >> start) & ((1ul << (end - start + 1)) - 1))
 
+#define FFA_PARTITION_INFO_V1_0_SIZE   8U
+#define FFA_PARTITION_INFO_V1_1_SIZE   24U
+#define FFA_PARTITION_INFO_V1_2_SIZE   24U
+#define FFA_PARTITION_INFO_V1_3_SIZE   48U
+
 /* 16-bit ID of FF-A component */
 typedef uint16_t ffa_endpoint_id_t;
 
@@ -182,16 +187,41 @@ typedef struct mailbox_buffers {
     void *send;
 } mb_buf_t;
 
+
+/*
+ * FF-A Partition Information Descriptor
+ *
+ * Based on:
+ *  - FF-A v1.0  : Basic partition identity
+ *  - FF-A v1.1+ : Adds protocol UUID
+ *  - FF-A v1.3  : Adds extended metadata (image UUID, versioning)
+ *
+ * Descriptor size by version:
+ *  - v1.0 : 8 bytes
+ *  - v1.1 / v1.2 : 24 bytes
+ *  - v1.3 : 48 bytes
+ *
+ * NOTE:
+ *  - Newer implementations (e.g., SPMC v1.3) may return larger descriptors
+ *    even if the endpoint supports an older version.
+ *  - Consumers MUST use the descriptor size returned by the ABI rather than
+ *    assuming a fixed version.
+ */
+
 typedef struct ffa_partition_info {
-    /** The ID of the VM the information is about */
-    ffa_endpoint_id_t id;
-    /** The number of execution contexts implemented by the partition */
-    uint16_t exec_context;
-    /** The Partition's properties, e.g. supported messaging methods */
-    uint32_t properties;
-#if (PLATFORM_FFA_V >= FFA_V_1_1)
-	uint32_t uuid[4];
-#endif
+
+        /* v1.0 */
+        ffa_endpoint_id_t id;   /* VM ID */
+        uint16_t exec_context;  /* vCPU count */
+        uint32_t properties;    /* flags */
+
+        /* v1.1 v1.2 */
+        uint32_t uuid[4];     /* protocol UUID */
+
+        /* v1.3 */
+        uint32_t image_uuid[4];        /* image UUID */
+        uint32_t partition_ffa_version;    /* FF-A version */
+        uint32_t reserved_0;               /* reserved */
 } ffa_partition_info_t;
 
 void val_call_conduit(ffa_args_t *args);

--- a/val/inc/val_ffa_helpers.h
+++ b/val/inc/val_ffa_helpers.h
@@ -537,4 +537,6 @@ uint32_t val_ffa_mem_handle_share(ffa_endpoint_id_t sender, ffa_endpoint_id_t re
 
 void val_ffa_mark_supported_fid(ffa_func_id_t fid, bool supported);
 
+void val_ffa_partition_descriptor_info_parser(ffa_partition_info_t *out, const void *rx_buf,
+                          uint64_t desc_size, uint64_t count);
 #endif /* VAL_FFA_HELPERS_H */

--- a/val/src/val_ffa_helpers.c
+++ b/val/src/val_ffa_helpers.c
@@ -379,3 +379,31 @@ void val_ffa_mark_supported_fid(ffa_func_id_t fid, bool supported)
          }
      }
 }
+
+/**
+ * @brief  - Parse FF-A partition descriptors from RX buffer into recent format
+ * @param  out       - Output array of ffa_partition_info_t
+ * @param  rx_buf    - Pointer to RX buffer containing descriptors
+ * @param  desc_size - Size of each descriptor in bytes (8 / 24 / 48)
+ * @param  count     - Number of descriptors in RX buffer
+ **/
+
+void val_ffa_partition_descriptor_info_parser(ffa_partition_info_t *out, const void *rx_buf,
+                          uint64_t desc_size, uint64_t count)
+{
+    const uint8_t *src = (const uint8_t *)rx_buf;
+
+    LOG(DBG, "Partition Descriptor size: %d\n", desc_size, 0);
+
+    for (uint32_t i = 0; i < count; i++) {
+
+        /* Clear full struct (ensures missing fields = 0) */
+        val_memset(&out[i], 0, sizeof(ffa_partition_info_t));
+
+        /* Copy only descriptor-sized data */
+        val_memcpy(&out[i], src, desc_size);
+
+        /* Move to next descriptor in buffer */
+        src += desc_size;
+    }
+}

--- a/val/src/val_framework.c
+++ b/val/src/val_framework.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021-2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -446,7 +446,7 @@ void val_ep_info_relayer_sync(void)
     const uint32_t null_uuid[4] = {0};
     uint64_t size = PAGE_SIZE_4K;
     uint32_t i = 0, j = 0;
-    uint32_t desc_count = 0;
+    uint32_t desc_size, desc_count = 0;
     uint32_t ep_count = 5;//val_get_endpoint_info_table_count();
     ffa_args_t payload;
 
@@ -487,7 +487,9 @@ void val_ep_info_relayer_sync(void)
         goto rx_release;
     }
     desc_count = (uint32_t)payload.arg2;
-    ret_info = (ffa_partition_info_t *)rx_buff;
+    desc_size = (uint32_t)payload.arg3;
+    ret_info = val_malloc(desc_count * sizeof(ffa_partition_info_t));
+    val_ffa_partition_descriptor_info_parser(ret_info, rx_buff, desc_size, desc_count);
 
     /* Print all rx descriptors */
     LOG(DBG, "Partition Descriptor count: %d\n", (int)payload.arg2);
@@ -503,14 +505,12 @@ void val_ep_info_relayer_sync(void)
         LOG(DBG, "+----------------------------------------------------------+\n");
     }
 
-    /* Validate returned descriptor size */
-    if (payload.arg3 != sizeof(ffa_partition_info_t))
-    {
-        LOG(ERROR, "Expected desc size %zu, got %d\n",
-            sizeof(ffa_partition_info_t), payload.arg2);
-        goto rx_release;
+    if (desc_size != FFA_PARTITION_INFO_V1_0_SIZE &&
+        desc_size != FFA_PARTITION_INFO_V1_1_SIZE &&
+        desc_size != FFA_PARTITION_INFO_V1_3_SIZE) {
+        LOG(ERROR, "Invalid descriptor size %u\n", desc_size);
+	goto rx_release;
     }
-
     /* Match each known endpoint against returned partition descriptors */
     for (i = 1; i < ep_count; i++)
     {


### PR DESCRIPTION
- Switched to v1.3 partition descriptor format
- Added common ffa_partition_info_t for all versions
- Implemented parser based on descriptor size
- Updated partition_info_get_t, regs and lsp tests
- Removed direct buffer casting, improved compatibility


